### PR TITLE
[NOMERGE] [UNTESTED] Require a word boundary after a mention

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -62,7 +62,7 @@ class Account < ApplicationRecord
   )
 
   USERNAME_RE   = /[a-z0-9_]+([a-z0-9_\.-]+[a-z0-9_]+)?/i
-  MENTION_RE    = /(?<=^|[^\/[:word:]])@((#{USERNAME_RE})(?:@[[:word:]\.\-]+[[:word:]]+)?)/i
+  MENTION_RE    = /(?<=^|[^\/[:word:]])@((#{USERNAME_RE})(?:@[[:word:]\.\-]+[[:word:]]+)?)(?:[[:space:]]|$)/i
   URL_PREFIX_RE = /\Ahttp(s?):\/\/[^\/]+/
 
   include Attachmentable

--- a/spec/services/process_mentions_service_spec.rb
+++ b/spec/services/process_mentions_service_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe ProcessMentionsService, type: :service do
         expect(remote_user.mentions.where(status: status).count).to eq 1
       end
     end
+
+    context 'with a malformed mention' do
+      let!(:remote_user) { Fabricate(:account, username: 'remote_user', protocol: :activitypub, domain: 'example.com', inbox_url: 'http://example.com/inbox') }
+      let(:status) { Fabricate(:status, account: account, text: "Hello @#{remote_user.acct}@osueth", visibility: visibility) }
+
+      before do
+        subject.call(status)
+      end
+
+      it 'does not create a mention' do
+        expect(remote_user.mentions.where(status: status).count).to eq 0
+      end
+    end
   end
 
   context 'Temporarily-unreachable ActivityPub user' do


### PR DESCRIPTION
`@alpha@example.org@ateohhoaush` being processed as a mention bugs me. The testing needs to be way more thorough, but it&#x2019;s a start.

**THIS HAS NOT BEEN TESTED.** GlitchCat is not running this code yet.

### Some thoughts for later

An idea that is not necessarily trivial: allow `i think @alpha/@beta would be well suited to this`. This is tricky because `https://twitter.com/@beta` should never be processed as a mention, which is probably why MENTION_RE forbids an immediately preceding `/`. However:

![image](https://user-images.githubusercontent.com/34298117/162387557-dd1079a2-9721-4f85-b882-be11689725d4.png)
![image](https://user-images.githubusercontent.com/34298117/162387606-18d4f578-c5e8-427b-af47-d519ae0c7295.png)

Here is the JSON of that status:

```
{
  "id": "108095281606656993",
  "created_at": "2022-04-08T07:31:40.686Z",
  "in_reply_to_id": "108095166497359093",
  "in_reply_to_account_id": "106886632504935780",
  "sensitive": true,
  "spoiler_text": "test posts",
  "visibility": "unlisted",
  "language": "en",
  "uri": "https://glitch.cat.family/users/aescling/statuses/108095281606656993",
  "url": "https://glitch.cat.family/@aescling/108095281606656993",
  "replies_count": 1,
  "reblogs_count": 1,
  "favourites_count": 0,
  "edited_at": null,
  "favourited": false,
  "reblogged": true,
  "muted": false,
  "bookmarked": false,
  "pinned": false,
  "local_only": false,
  "content": "<p><a href=\"https://example.org/.@kindle@plural.cafe\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">example.org/.@kindle@plural.ca</span><span class=\"invisible\">fe</span></a></p>",
  "reblog": null,
  "application": {
    "name": "Web",
    "website": null
  },
  "account": {
    "id": "106886632504935780",
    "username": "aescling",
    "acct": "aescling",
    "display_name": "sword syscatmin woman",
    "locked": true,
    "bot": false,
    "discoverable": true,
    "group": false,
    "created_at": "2021-09-06T00:00:00.000Z",
    "note": "<p>black cat made entirely of fire, they/she/it/æ; co-admin(s) what manage the technical infrastructure. it’s pronounced “ashling”; “æsc” and “cat” also work</p><p>follow requests open!<br />@ us about</p><p>* technical issues regarding the instance;<br />* smash ultimate,<br />* weird small software,<br />* dragons<br />* pupys of any kind, and, of course,<br />* cats ;3</p><p>as we have a job and other hobbies, please understand that we cannot always address a technical issue right away.</p><p>reachable via email and matrix, with the same account details as here; DM if you need contact details for another protocol</p>",
    "url": "https://glitch.cat.family/@aescling",
    "avatar": "https://media.glitch.cat.family/accounts/avatars/106/886/632/504/935/780/original/d58c5cca4b0b1da3.jpg",
    "avatar_static": "https://media.glitch.cat.family/accounts/avatars/106/886/632/504/935/780/original/d58c5cca4b0b1da3.jpg",
    "header": "https://glitch.cat.family/headers/original/missing.png",
    "header_static": "https://glitch.cat.family/headers/original/missing.png",
    "followers_count": 32,
    "following_count": 54,
    "statuses_count": 8901,
    "last_status_at": "2022-04-08",
    "emojis": [],
    "fields": [
      {
        "name": "website",
        "value": "<a href=\"https://æscling.cat.family\" target=\"_blank\" rel=\"nofollow noopener noreferrer me\"><span class=\"invisible\">https://</span><span class=\"\">æscling.cat.family</span><span class=\"invisible\"></span></a>",
        "verified_at": null
      },
      {
        "name": "neopronouns",
        "value": "æ / ær / æi / æin / æinselves",
        "verified_at": null
      },
      {
        "name": "avatar",
        "value": "@saltmalkin@twitter.com, ink on paper",
        "verified_at": null
      }
    ]
  },
  "media_attachments": [],
  "mentions": [
    {
      "id": "106910029666214247",
      "username": "kindle",
      "url": "https://plural.cafe/@kindle",
      "acct": "kindle@plural.cafe"
    }
  ],
  "tags": [],
  "emojis": [],
  "card": null,
  "poll": null
}
```